### PR TITLE
fix perm to octal

### DIFF
--- a/packages/utils/file.go
+++ b/packages/utils/file.go
@@ -17,7 +17,7 @@ import (
 // PUBLIC
 
 func WriteToFile(data []byte, pathToFile string) error {
-	err := ioutil.WriteFile(pathToFile, data, 777)
+	err := ioutil.WriteFile(pathToFile, data, 0777)
 	return err
 }
 


### PR DESCRIPTION
Hi.
I found you passing a perm for WriteFile method as decimal.
But you want to pass it as octal arn't you?

For example, 
`0777` is `111111111` in binary and it means `rwxrwxrwx`.
`777` is `1100001001` in binary and it means `r----x--x`.
